### PR TITLE
updating caddy-ubi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:0d6954b
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9
 
 ENV CADDY_TLS_MODE="http_port 8000"
 


### PR DESCRIPTION
Rolling out a new version of Caddy UBI that contains updated dependency versions.