### PR TITLE
Update caddy-ubi image to latest tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:094d8a9
+FROM quay.io/redhat-services-prod/hcm-eng-prod-tenant/caddy-ubi:ba24e49@sha256:bcdcda167c46439356640b50c3ecfb23486037ee5bc04103b46f81c9fc587e60
 
 ENV CADDY_TLS_MODE="http_port 8000"
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    ":disableMajorUpdates",
+    "github>konflux-ci/mintmaker-presets:cve-automerge-all"
+  ]
+}


### PR DESCRIPTION
Also pin the digest to be able to get PRs from mintmaker since sha-like tags are not supported by it.
